### PR TITLE
add manpages and improve spanish version

### DIFF
--- a/_data/locales/es.yml
+++ b/_data/locales/es.yml
@@ -1,9 +1,10 @@
 software: Software
 documentation: Documentación
+manpages: Páginas man
 wiki: Wiki
 wiki_url: https://es.opensuse.org
 forums: Foro
-forums_url: https://forums.opensuse.org/forumdisplay.php/837-Espa%C3%B1ol
+forums_url: https://forums.opensuse.org/c/espanol-spanish/14
 development: Desarrollo
 build_service: Servicio de compilaciones
 information: Información
@@ -22,8 +23,9 @@ main: Principal
 main_site: Sitio principal
 telegram_group: Grupo de Telegram
 telegram_group_url: https://t.me/openSUSE_ES
-other: Otro
+other: Otros
 unofficial_guide: Guía (no oficial)
+unofficial_guide_url: https://victorhck.gitlab.io/guia_openSUSE/
 mirrors: Espejos
 kernel: Kernel
 status: Estado

--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -16,6 +16,10 @@
     icon: doc.svg
     url: https://doc.opensuse.org/
 
+  - id: manpages
+    icon: doc.svg
+    url: https://manpages.opensuse.org/
+
   - id: forums
     icon: forums.svg
     url: https://forums.opensuse.org/


### PR DESCRIPTION
I think that also be useful to add manpages link in navbar in openSUSE pages (I don't know how to do that, can't find where is that code...)