### PR TITLE
Fix menu item issue with logo/trademark

### DIFF
--- a/_data/locales/en.yml
+++ b/_data/locales/en.yml
@@ -23,6 +23,7 @@ kernel: Kernel
 information: Information
 news: News
 events: Events
+artwork: Logo/Trademark
 planet: Planet
 shop: Shop
 status: Status

--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -58,7 +58,7 @@
     icon: events.svg
     url: https://events.opensuse.org/
 
-  - id: Logo/Trademark
+  - id: artwork
     icon: openSUSE.svg
     url: https://en.opensuse.org/openSUSE:Artwork_brand
 


### PR DESCRIPTION
While working on the new get.opensuse.org frontpage I noticed an issue with the Logo/Trademark item. Compare normal item with non-normal item:

![image](https://github.com/user-attachments/assets/b5cc23f2-8dcc-41d6-b948-76d18016a535)

As the title is left empty, I see an empty item in my layout:

![image](https://github.com/user-attachments/assets/f8ee1f4f-7f55-47c3-b266-24bdb96b7fae)

I _think_ I made the correct edit, but I haven't been able to validate it due to this:

```
$ bundle exec jekyll serve --incremental
/home/pieter/.gem/gems/jekyll-4.3.1/lib/jekyll.rb:28:in 'Kernel#require': cannot load such file -- csv (LoadError)
        from /home/pieter/.gem/gems/jekyll-4.3.1/lib/jekyll.rb:28:in '<top (required)>'
        from /home/pieter/.gem/gems/jekyll-4.3.1/exe/jekyll:8:in 'Kernel#require'
        from /home/pieter/.gem/gems/jekyll-4.3.1/exe/jekyll:8:in '<top (required)>'
        from /home/pieter/.gem/bin/jekyll:25:in 'Kernel#load'
        from /home/pieter/.gem/bin/jekyll:25:in '<main>'
```