### PR TITLE
Add missing translation string

### DIFF
--- a/_data/locales/en.yml
+++ b/_data/locales/en.yml
@@ -30,6 +30,7 @@ status: Status
 survey: Survey
 search: Search
 community: Community
+code_of_conduct: Code of Conduct
 irc_channels: IRC Channels
 mailing_lists: Mailing Lists
 facebook_group: Facebook Group


### PR DESCRIPTION
The Code of Conduct was recently added, but its translation wasn't.